### PR TITLE
Determine the destination directory from the script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,7 @@ You install `install-files` into the package with the files to install, as per t
 You should recommend that the package with the files to install is installed as a dev dependency
 (`npm install my-ebextensions --save-dev`, for example) so that it does not try to install the
 files in a production environment. The files should have been installed and committed prior to then
-(when the package was installed locally), so this work should be redundant; and trying to install
-the files on the production server can result in weird effects if for instance you're caching your
-Node modules somewhere other than your application directory.
+(when the package was installed locally), so this work should be redundant.
 
 ## Usage details
 
@@ -113,4 +111,5 @@ To run the Node tests: `npm test`.
 
 ## Release History
 
+* 1.0.1 Properly determine the host package's directory even if its Node modules are cached elsewhere
 * 1.0.0 Initial release.

--- a/spec/indexSpec.js
+++ b/spec/indexSpec.js
@@ -2,6 +2,7 @@
 var mockFs = require('mock-fs');
 var denodeify = require('denodeify');
 var installFiles = denodeify(require('../src'));
+var path = require('path');
 var readdir = denodeify(require('fs').readdir);
 var readFile = denodeify(require('fs').readFile);
 
@@ -14,7 +15,7 @@ describe('installFiles', function() {
   });
 
   describe('installing', function() {
-    var previousNpmLifecycleEvent;
+    var previousNpmLifecycleEvent, previousScriptPath;
 
     beforeEach(function() {
       previousNpmLifecycleEvent = process.env.npm_lifecycle_event;
@@ -26,7 +27,10 @@ describe('installFiles', function() {
       //
       // The `mockFs` calls below will create the directory structure for this. The other file paths
       // will be relative to this.
-      spyOn(process, 'cwd').and.returnValue('/foo/bar/node_modules/ebextensions');
+      var fileInstallingPackagePath = '/foo/bar/node_modules/ebextensions';
+      spyOn(process, 'cwd').and.returnValue(fileInstallingPackagePath);
+      previousScriptPath = process.env._;
+      process.env._ = path.join(fileInstallingPackagePath, '/node_modules/.bin/install-files');
 
       // Create a mock file system just as safety belts for a test forgetting to do so.
       mockFs();
@@ -34,6 +38,7 @@ describe('installFiles', function() {
 
     afterEach(function() {
       process.env.npm_lifecycle_event = previousNpmLifecycleEvent;
+      process.env._ = previousScriptPath;
       mockFs.restore();
     });
 

--- a/src/hostPackageDir.js
+++ b/src/hostPackageDir.js
@@ -1,15 +1,15 @@
 var path = require('path');
 
 /**
- * Determines the directory of the package containing the specified directory.
+ * Determines the directory of the package containing the specified file.
  *
- * @param {String} dir - The path to a directory, e.g. the directory of a dependency.
+ * @param {String} file - The path to a file.
  *
- * @return {String} - The path to the package containing _dir_, or `undefined` if the path cannot
- *   be determined e.g. _dir_ is not contained within a package.
+ * @return {String} - The path to the package containing _file_, or `undefined` if the path cannot
+ *   be determined e.g. _file_ is not contained within a package.
  */
-function hostPackageDir(dir) {
-  var pathComponents = dir.split(path.sep);
+function hostPackageDir(file) {
+  var pathComponents = file.split(path.sep);
   var modulesDirIndex = pathComponents.lastIndexOf('node_modules');
   if (modulesDirIndex < 1) return undefined;
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,9 +24,15 @@ function installFiles(sourceDir, done) {
     return;
   }
 
-  // When this is called from a package's 'install' or 'postinstall' script, we expect `process.cwd()`
-  // to be the directory of that package. Thus, we should install into _its_ host package's directory.
-  var destinationDir = hostPackageDir(process.cwd());
+  // When this is called from a package's 'install' or 'postinstall' script, this will be the path
+  // to `install-files` within that package's `node_modules/.bin` directory.
+  var scriptPath = process.env._;
+
+  // The path to the package running the 'install' or 'postinstall' script.
+  var fileInstallingPackagePath = hostPackageDir(scriptPath);
+
+  // The path to the package into which we should install the files.
+  var destinationDir = fileInstallingPackagePath && hostPackageDir(fileInstallingPackagePath);
   if (!destinationDir) {
     var error2 = new Error('Could not determine the install destination directory.');
     process.nextTick(() => done(error2));


### PR DESCRIPTION
Rather than the working directory, since the working directory is relative to
the host package’s `node_modules` directory rather than to the host package
itself. This is an issue when the `node_modules` directory is cached
somewhere other than the host package directory.

Example: say `app` is the package into which files should be installed,
`my-ebextensions` is the file-installing package, and `app/node_modules`
is a symlink to `/var/node_modules`. Then, from the perspective of
`install-files`, `process.cwd()` will be `/var/node_modules/my-ebextensions`,
and previously it would try to install its files into `/var`.

However `process.env._` is still
`app/node_modules/my-ebextensions/node_modules/.bin/install-files`,
so we can determine `app`’s path from that.