### PR TITLE
Ensure install/postinstall does not run on self.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ var hostPackageDir = require('./hostPackageDir');
 var ncp = require('ncp');
 var npmv = require('./npm-version');
 var path = require('path');
+var fs = require('fs');
 
 /**
  * Copies the files contained within _sourceDir_ into a host package's directory when called from
@@ -33,6 +34,9 @@ function installFiles(sourceDir, done) {
   // The path to the package running the 'install' or 'postinstall' script.
   var fileInstallingPackagePath = hostPackageDir(scriptPath);
 
+  // The target package responsible for the 'install' or 'postinstall' event
+  var installTargetPackageName = process.env.npm_package_name;
+
   var source, target;
   switch (npmv.majorVersion()) {
     case '1':
@@ -46,7 +50,7 @@ function installFiles(sourceDir, done) {
       console.log("[install-files]: WARNING: Could not determine NPM version");
       /* falls through */
     default:
-      source = path.join(fileInstallingPackagePath, 'node_modules', process.env.npm_package_name, sourceDir);
+      source = path.join(fileInstallingPackagePath, 'node_modules', installTargetPackageName, sourceDir);
       target = fileInstallingPackagePath;
   }
 
@@ -56,11 +60,33 @@ function installFiles(sourceDir, done) {
     return;
   }
 
+  // If install destination is the current module, we can silently skip
+  if (installTargetPackageName == getModulePackageName(target)) {
+    process.nextTick(() => done());
+    return;
+  }
+
   ncp(source, target, {
     // Intentionally overwrite existing files.
     // This lets the file-installing package push a new version of files to dependents when it is updated.
     clobber: true
   }, done);
+}
+
+/**
+ * Attempt to determine the module's package name. If package.json exists, use the name 
+ * attribute from there; otherwise, infer a name from the directory structure
+ *
+ * @param {String} target - the target directory 
+*/
+function getModulePackageName(target) {
+  var packageName;
+  try {
+    packageName = JSON.parse(fs.readFileSync(path.join(target, 'package.json'), 'utf8')).name;
+  } catch (e) {
+    packageName = path.basename(target);
+  }
+  return packageName;
 }
 
 module.exports = installFiles;


### PR DESCRIPTION
The intention here is to avoid error messages like the following (particularly npm v3, but I'd imagine a similar issue with any version):

```sh
&> npm install

> my-ebextension@1.0.8 install /path/to/my-ebextension
> install-files shared

[ { Error: ENOENT: no such file or directory, lstat '/path/to/my-ebextension/node_modules/my-ebextension/shared'
      at Error (native)
    errno: -2,
    code: 'ENOENT',
    syscall: 'lstat',
    path: '/path/to/my-ebextension/node_modules/my-ebextension/shared' } ]
└── install-files@1.1.1 
```

The interesting bit of my-ebextension's package.json looks like:

```json
"scripts": {
    "install": "install-files shared",
}
```

which, of course, is required for `my-microservice`.  But there are also other dependencies declared, unrelated to install-files, that require `npm install` to run, as `my-ebextension` provides additional code and services to `my-microservice`.

In this case, the failing code path is skipped because either the module name found in `/path/to/my-ebextension/package.json` or, that failing, the `path.basename` of `/path/to/my-ebextension` is the same as the package name, `my-ebextension`.  I moved away from the regex as the filter would have erroneously caught things like `foo-my-ebextension`.

Now, I am no longer seeing the above error, and installing package name can be sought more reliably to avoid self-targeting.