### PR TITLE
Fix non-flattened invocation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,11 @@ function installFiles(sourceDir, raw, done) {
   // The target package responsible for the 'install' or 'postinstall' event
   var installTargetPackageName = process.env.npm_package_name;
 
+  // When this is called from a package's 'install' or 'postinstall' script, this will be the path
+  // to the root of the package that has the 'install-files' hook in its package.json. This solves
+  // problems where npm doesn't flatten install-files because of conflicting versions.
+  var invokingPackage = process.env.PWD;
+
   var npmVersion = npmv.majorVersion();
 
   if (npmVersion === '1') {
@@ -65,7 +70,16 @@ function installFiles(sourceDir, raw, done) {
   if (npmv.isYarn() || ['1', '2'].indexOf(npmVersion) >= 0) {
     source = sourceDir;
     target = fileInstallingPackagePath && hostPackageDir(fileInstallingPackagePath);
+  } else if (invokingPackage) {
+    // We know the package that's invoking us, so we just append the source directory.
+    source = path.join(invokingPackage, sourceDir);
+
+    // Get the directory of the package that hosts the invoking package. This isn't bulletproof, but
+    // it's the best guess we have.
+    target = invokingPackage && hostPackageDir(invokingPackage);
   } else {
+    // We expect PWD to be available at all times, but just in case it isn't, we fall back to
+    // previous behavior.
     source = path.join(fileInstallingPackagePath, 'node_modules', installTargetPackageName, sourceDir);
     target = fileInstallingPackagePath;
   }


### PR DESCRIPTION
If we have two packages containing files to install, and they reference different major versions of install-files, the install-files script will silently [skip the installation](https://github.com/mixmaxhq/install-files/blob/14f019c9221d171b47b3cd1bea977d2c3c197285/src/index.js#L79-L83).

npm v6 includes the (standard) `PWD` environment variable. Other versions of npm (and possibly yarn) may also allow this environment variable, but until we confirm we just restrict this to newer versions of npm (>= 3).